### PR TITLE
Add Dockerfile module for run/debug/deployment

### DIFF
--- a/generators.json
+++ b/generators.json
@@ -2,8 +2,8 @@
   "generators": [
     {
       "name": "Ambassador Labs Go Generator",
-      "description": "Generates a new project for an API server writen in go",
-      "version": "0.0.3",
+      "description": "Generates a new project for an API server written in go",
+      "version": "0.0.4",
       "languages": ["go"],
       "dir_name": "go"
     }]

--- a/generators/go/generator-config.yaml
+++ b/generators/go/generator-config.yaml
@@ -1,7 +1,7 @@
 metadata:
   name: "Ambassador Labs Go Generator"
-  description: "Generates a new project for an API server writen in go"
-  version: "0.0.3"
+  description: "Generates a new project for an API server written in go"
+  version: "0.0.4"
   languages: ["go"]
 
 # Defines the base directory within the template folder.
@@ -93,6 +93,10 @@ modules:
   requiredModules: []  # TODO: not implemented yet
 - name: Readme
   sourceDir: modules/readme
+  targetDir: base
+  requiredModules: []
+- name: Dockerfile
+  sourceDir: modules/Dockerfile
   targetDir: base
   requiredModules: []
 

--- a/generators/go/modules/dockerfile/Dockerfile.template
+++ b/generators/go/modules/dockerfile/Dockerfile.template
@@ -1,0 +1,29 @@
+FROM golang:{{{ .GoVersion }}}-alpine AS base
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+WORKDIR /build
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY cmd cmd
+COPY internal internal
+
+FROM base AS builder
+
+WORKDIR cmd/{{{ .ProjectName }}}
+RUN go build -o /build/{{{ .ProjectName }}} .
+
+FROM base AS debug
+WORKDIR cmd/{{{ .ProjectName }}}
+RUN go build -gcflags="all=-N -l" -o /build/{{{ .ProjectName }}} .
+
+ENV DEBUG_PORT=2345
+EXPOSE $DEBUG_PORT
+ENTRYPOINT /go/bin/dlv --listen=:$DEBUG_PORT --headless=true --api-version=2 --accept-multiclient exec /build/{{{ .ProjectName }}}
+
+FROM alpine AS run
+COPY --from=builder /build/{{{ .ProjectName }}} /
+CMD ["/{{{ .ProjectName }}}"]
+

--- a/generators/go/modules/dockerfile/Dockerfile.template
+++ b/generators/go/modules/dockerfile/Dockerfile.template
@@ -12,18 +12,18 @@ COPY internal internal
 
 FROM base AS builder
 
-WORKDIR cmd/{{{ .ProjectName }}}
-RUN go build -o /build/{{{ .ProjectName }}} .
+WORKDIR cmd/{{{ _toDir .ProjectName }}}
+RUN go build -o /build/{{{ _toDir .ProjectName }}} .
 
 FROM base AS debug
-WORKDIR cmd/{{{ .ProjectName }}}
-RUN go build -gcflags="all=-N -l" -o /build/{{{ .ProjectName }}} .
+WORKDIR cmd/{{{ _toDir .ProjectName }}}
+RUN go build -gcflags="all=-N -l" -o /build/{{{ _toDir .ProjectName }}} .
 
 ENV DEBUG_PORT=2345
 EXPOSE $DEBUG_PORT
-ENTRYPOINT /go/bin/dlv --listen=:$DEBUG_PORT --headless=true --api-version=2 --accept-multiclient exec /build/{{{ .ProjectName }}}
+ENTRYPOINT /go/bin/dlv --listen=:$DEBUG_PORT --headless=true --api-version=2 --accept-multiclient exec /build/{{{ _toDir .ProjectName }}}
 
 FROM alpine AS run
-COPY --from=builder /build/{{{ .ProjectName }}} /
-CMD ["/{{{ .ProjectName }}}"]
+COPY --from=builder /build/{{{ _toDir .ProjectName }}} /
+CMD ["/{{{ _toDir .ProjectName }}}"]
 


### PR DESCRIPTION
## Description
Adds a new option for creating a simple Dockerfile that enables the usage of `code run`, `code debug`, and `deployment create` based on options entered when running `code generate` for Go.

## Screenshots
### Prompt
![Screen Shot 2024-06-04 at 11 18 59 AM](https://github.com/datawire/generators/assets/987830/3d9a8f28-459b-4186-8742-e9877bec1817)

### Output
![Screen Shot 2024-06-04 at 11 20 14 AM](https://github.com/datawire/generators/assets/987830/5855cd57-4b73-4d43-ae55-b8cd5318e5fe)
