### PR TITLE
Use port 80 as a temporary workaround for deployment

### DIFF
--- a/generators.json
+++ b/generators.json
@@ -3,7 +3,7 @@
     {
       "name": "Ambassador Labs Go Generator",
       "description": "Generates a new project for an API server written in go",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "languages": ["go"],
       "dir_name": "go"
     }]

--- a/generators/go/base/internal/binary/server.go.template
+++ b/generators/go/base/internal/binary/server.go.template
@@ -27,7 +27,7 @@ func NewAPIService() *apiService {
 	output := zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}
 	logger := zerolog.New(output).With().Timestamp().Logger()
 	return &apiService{
-		addr:   ":8080",
+		addr:   ":80",
 		logger: logger,
 	}
 }

--- a/generators/go/generator-config.yaml
+++ b/generators/go/generator-config.yaml
@@ -1,7 +1,7 @@
 metadata:
   name: "Ambassador Labs Go Generator"
   description: "Generates a new project for an API server written in go"
-  version: "0.0.4"
+  version: "0.0.5"
   languages: ["go"]
 
 # Defines the base directory within the template folder.


### PR DESCRIPTION
## Description
Currently, generated server code listens on port 8080, but the deployment functionality only works with port 80.  This requirement means that generated code must be updated to listen on port 80, causing friction when demoing.  Making deployment more robust is lift and needs to be done.  In the meantime, as a quick workaround, the port in the generated code can be set to 80, removing the need for an update, until the long term change for deployments are in place.