### PR TITLE
fix go gen docker module

### DIFF
--- a/generators/go/generator-config.yaml
+++ b/generators/go/generator-config.yaml
@@ -96,7 +96,7 @@ modules:
   targetDir: base
   requiredModules: []
 - name: Dockerfile
-  sourceDir: modules/Dockerfile
+  sourceDir: modules/dockerfile
   targetDir: base
   requiredModules: []
 


### PR DESCRIPTION
fixes the config for the docker module since the directory is lowercase `dockerfile`.