### PR TITLE
Set a user to work with new security policy

### DIFF
--- a/generators/go/modules/dockerfile/Dockerfile.template
+++ b/generators/go/modules/dockerfile/Dockerfile.template
@@ -25,5 +25,6 @@ ENTRYPOINT /go/bin/dlv --listen=:$DEBUG_PORT --headless=true --api-version=2 --a
 
 FROM alpine AS run
 COPY --from=builder /build/{{{ _toDir .ProjectName }}} /
+USER 1000
 CMD ["/{{{ _toDir .ProjectName }}}"]
 


### PR DESCRIPTION
### Description
Recently, changes were made to the security policy for Blackbird deployments that disallow containers running as root.  This update ensures that the code generated Dockerfile will work with the new restrictions without user intervention.

Closes https://github.com/datawire/generators/issues/10